### PR TITLE
[filament_scene] Ensures plugin init before Filament view build

### DIFF
--- a/packages/filament_scene/example/lib/demo_widgets.dart
+++ b/packages/filament_scene/example/lib/demo_widgets.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:math';
 
 import 'package:filament_scene/engine.dart';
 import 'package:flutter/material.dart';
@@ -290,21 +291,35 @@ class _FrameProfilingOverlayState extends State<FrameProfilingOverlay> {
                 Row(
                   mainAxisAlignment: MainAxisAlignment.end,
                   crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    for (int i = 0; i < _fpsHistory.length; i++)
-                      Container(
-                        width: kPerfBarWidth,
-                        // dart format off
-                        height: kPerfBarHeight * (
+                  children: (() {
+                    final bars = <Widget>[];
+
+                    for (int i = 0; i < _fpsHistory.length; i++) {
+                      // dart format off
+                        final double value = (
                           _cpuHistory.elementAt(i) +
                           _gpuHistory.elementAt(i) +
                           _scpHistory.elementAt(i) //
-                        ) / kExpectedFrameTime,
+                        ) / kExpectedFrameTime;
                         // dart format on
-                        margin: const EdgeInsets.only(right: 1),
-                        color: Colors.green,
-                      ),
-                  ],
+
+                      bars.add(
+                        Container(
+                          width: kPerfBarWidth,
+                          height: kPerfBarHeight * min(value, 1),
+                          margin: const EdgeInsets.only(right: 1),
+                          color: [
+                            // dart format off
+                            Colors.green,
+                            Colors.yellow,
+                            Colors.red
+                          ][(min(value, 1) * 2).floor()] // dart format on
+                        ),
+                      );
+                    }
+
+                    return bars;
+                  })(),
                 ),
                 // Chart labels
                 Column(

--- a/packages/filament_scene/example/lib/main.dart
+++ b/packages/filament_scene/example/lib/main.dart
@@ -109,9 +109,16 @@ class _MyAppState extends State<MyApp> {
     super.initState();
 
     _filamentViewWidget = poGetFilamentScene();
-    _setScene(0);
 
-    unawaited(initializeReadiness());
+    unawaited(
+      initializeReadiness().then((isReady) {
+        if (isReady) {
+          setState(() {
+            _setScene(0);
+          });
+        }
+      }),
+    );
   }
 
   /// Call only from setState
@@ -151,7 +158,7 @@ class _MyAppState extends State<MyApp> {
     };
   }
 
-  Future<void> initializeReadiness() async {
+  Future<bool> initializeReadiness() async {
     const int maxRetries = 30;
     const Duration retryInterval = Duration(seconds: 1);
 
@@ -163,18 +170,20 @@ class _MyAppState extends State<MyApp> {
         if (nativeReady) {
           print('Native is ready. Proceeding...');
           startListeningForEvents();
-          return;
+          return true;
         } else {
           print('Native is not ready. Retrying...');
         }
       } catch (e) {
         print('Error checking readiness: $e');
+        return false;
       }
 
       await Future.delayed(retryInterval);
     }
 
     print('Failed to confirm native readiness after $maxRetries attempts.');
+    return false;
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/packages/filament_scene/lib/scene/scene_widget.dart
+++ b/packages/filament_scene/lib/scene/scene_widget.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:core';
+import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:filament_scene/camera/camera.dart';
@@ -133,8 +134,10 @@ class ModelViewerState extends State<SceneView> {
 
   @override
   void initState() {
-    _setupCreationParams();
     super.initState();
+    _setupCreationParams();
+
+    DartPluginRegistrant.ensureInitialized();
   }
 
   @override


### PR DESCRIPTION
Fixes toyota-connected/fluorite#12

## Description

Fixes Flutter app trying to access the API before the engine is ready.
Currently this is a fix in the example app, a better solution in the fluorite package is needed in the long term.

Closes https://github.com/toyota-connected/fluorite/issues/12

See https://github.com/toyota-connected/fluorite/issues/12#issuecomment-3217104918 for details

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
