### PR TITLE
[filament_scene] Fixes script event related stutterFix/fs script timing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ gradlew.bat
 packages/camera/camera_linux/example/.desktop-homescreen*
 packages/video_player/video_player_linux/example/.desktop-homescreen*
 packages/webview/webview_flutter_linux/example/.desktop-homescreen*
+
+packages/filament_scene/example/devtools_options.yaml

--- a/packages/filament_scene/example/lib/demo_widgets.dart
+++ b/packages/filament_scene/example/lib/demo_widgets.dart
@@ -183,7 +183,7 @@ class FrameProfilingOverlay extends StatefulWidget {
 
 class _FrameProfilingOverlayState extends State<FrameProfilingOverlay> {
   static int expectedFPS = 60; // Expected FPS for the graph
-  double get expectedFrameTime => 1000 / expectedFPS; // Expected frame time in milliseconds
+  double get expectedFrameTime => 1000.0 / expectedFPS; // Expected frame time in milliseconds
 
   late final ListQueue<double> _fpsHistory;
   late final ListQueue<double> _totHistory;
@@ -333,25 +333,28 @@ class _FrameProfilingOverlayState extends State<FrameProfilingOverlay> {
                           final bars = <Widget>[];
 
                           for (int i = 0; i < _fpsHistory.length; i++) {
-                            // dart format off
-                            final double value = (
-                              _cpuHistory.elementAt(i) +
-                              _gpuHistory.elementAt(i) +
-                              _scpHistory.elementAt(i)
-                            ) / expectedFrameTime;
-                            // dart format on
+                            final double value = (_totHistory.elementAt(i)) / expectedFrameTime;
+
+                            final sysDelay =
+                                (_sysHistory.elementAt(i) - 1) >
+                                (expectedFrameTime - _totHistory.elementAt(i));
 
                             bars.add(
                               Container(
+                                key: ValueKey('perf_bar_$i'),
                                 width: kPerfBarWidth,
                                 height: kPerfBarHeight * min(value, 1),
                                 margin: const EdgeInsets.only(right: 1),
-                                color: [
-                                  // dart format off
-                            Colors.green,
-                            Colors.yellow,
-                            Colors.red
-                          ][(min(value, 1) * 2).floor()] // dart format on
+                                color: // dart format off
+                                  // Red if value > 1
+                                  value > 1 ? Colors.red :
+                                  // Orange if sysDelay
+                                  sysDelay ? Colors.orangeAccent :
+                                  // Yellow if value > 0.5
+                                  value > 0.5 ? Colors.yellow :
+                                  // Green otherwise
+                                  Colors.green,
+                                // dart format on
                               ),
                             );
                           }
@@ -424,9 +427,9 @@ class _FrameProfilingOverlayState extends State<FrameProfilingOverlay> {
                     // Glow red if delay causes low FPS
                     // dart format off
                     color:
-                        (_sysHistory.lastOrNull ?? 0) >
+                        ((_sysHistory.lastOrNull ?? 0) - 1) >
                         (expectedFrameTime - (_totHistory.lastOrNull ?? 0))
-                          ? Colors.redAccent
+                          ? Colors.orangeAccent
                           : Colors.white,
                     // dart format on
                   ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

Partial fix to https://github.com/toyota-connected/fluorite/issues/11

## Description

Makes it so the script events called Core -> Dart are being awaited before the frame is complete.

Also contains:
- Improvements to the trainset demo to try and reduce garbage collection (script-driven stutter)
- Improvement to the frame profiler, so the frames affected by system delay are now painted orange

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
