### PR TITLE
[video_player_linux] player UI overhaul: overlays, sliding trays, perf

### DIFF
--- a/packages/video_player/video_player_linux/example/player/lib/main.dart
+++ b/packages/video_player/video_player_linux/example/player/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'library.dart';
@@ -32,61 +34,271 @@ class HomeScreen extends StatefulWidget {
   State<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen> {
-  int _selectedIndex = 0;
+class _HomeScreenState extends State<HomeScreen>
+    with SingleTickerProviderStateMixin {
   MediaItem? _nowPlaying;
 
-  void _playItem(MediaItem item) {
-    setState(() {
-      _nowPlaying = item;
-      _selectedIndex = 1;
+  late final AnimationController _paneAnim;
+  Timer? _paneTimer;
+  static const _paneTimeout = Duration(seconds: 10);
+
+  // Pointer activity tracking for the library button
+  bool _pointerActive = false;
+  Timer? _activityTimer;
+  static const _activityTimeout = Duration(seconds: 3);
+
+  @override
+  void initState() {
+    super.initState();
+    _paneAnim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+      value: 1.0, // start revealed
+    );
+  }
+
+  @override
+  void dispose() {
+    _activityTimer?.cancel();
+    _paneTimer?.cancel();
+    _paneAnim.dispose();
+    super.dispose();
+  }
+
+  void _onPointerActivity() {
+    if (!_pointerActive) {
+      setState(() => _pointerActive = true);
+    }
+    _activityTimer?.cancel();
+    _activityTimer = Timer(_activityTimeout, () {
+      if (mounted) setState(() => _pointerActive = false);
     });
+  }
+
+  void _showPane() {
+    _paneAnim.forward();
+    // Only auto-hide after a video has been played at least once.
+    if (_nowPlaying != null) {
+      _restartPaneTimer();
+    }
+  }
+
+  void _hidePane() {
+    _paneTimer?.cancel();
+    _paneAnim.reverse();
+  }
+
+  void _restartPaneTimer() {
+    _paneTimer?.cancel();
+    _paneTimer = Timer(_paneTimeout, _hidePane);
+  }
+
+  void _pokePane() {
+    if (_paneAnim.value < 1.0) {
+      _showPane();
+    } else {
+      _restartPaneTimer();
+    }
+  }
+
+  void _playItem(MediaItem item) {
+    setState(() => _nowPlaying = item);
+    _hidePane();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Row(
-        children: [
-          NavigationRail(
-            selectedIndex: _selectedIndex,
-            onDestinationSelected: (index) {
-              setState(() => _selectedIndex = index);
-            },
-            labelType: NavigationRailLabelType.all,
-            leading: Padding(
-              padding: const EdgeInsets.only(bottom: 8),
-              child: Icon(
-                Icons.play_circle_filled,
-                size: 40,
-                color: Theme.of(context).colorScheme.primary,
+      body: Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: (_) => _onPointerActivity(),
+        onPointerMove: (_) => _onPointerActivity(),
+        onPointerHover: (_) => _onPointerActivity(),
+        child: Stack(
+          children: [
+            // Player — always fills the entire area
+            Positioned.fill(
+              child: PlayerScreen(item: _nowPlaying),
+            ),
+
+            // Left pane — slides in from the left, retracts fully
+            Positioned(
+              left: 0,
+              top: 0,
+              bottom: 0,
+              child: _LeftPaneTray(
+                animation: _paneAnim,
+                onInteraction: _pokePane,
+                child: _LeftPaneContent(
+                  onPlay: _playItem,
+                  onInteraction: _pokePane,
+                ),
               ),
             ),
-            destinations: const [
-              NavigationRailDestination(
-                icon: Icon(Icons.video_library_outlined),
-                selectedIcon: Icon(Icons.video_library),
-                label: Text('Library'),
+
+            // Left-edge swipe zone to open library pane
+            Positioned(
+              left: 0,
+              top: 0,
+              bottom: 0,
+              width: 20,
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onHorizontalDragUpdate: (details) {
+                  if (details.primaryDelta != null &&
+                      details.primaryDelta! > 2) {
+                    _showPane();
+                  }
+                },
               ),
-              NavigationRailDestination(
-                icon: Icon(Icons.play_circle_outline),
-                selectedIcon: Icon(Icons.play_circle),
-                label: Text('Player'),
-              ),
-            ],
-          ),
-          const VerticalDivider(thickness: 1, width: 1),
-          Expanded(
-            child: IndexedStack(
-              index: _selectedIndex,
-              children: [
-                LibraryScreen(onPlay: _playItem),
-                PlayerScreen(item: _nowPlaying),
-              ],
             ),
-          ),
-        ],
+
+            // Library button — transparent, lights up on hover/touch
+            Positioned(
+              left: 8,
+              top: 8,
+              child: AnimatedBuilder(
+                animation: _paneAnim,
+                builder: (context, child) {
+                  // Hide button when pane is fully open
+                  return Opacity(
+                    opacity: 1.0 - _paneAnim.value,
+                    child: IgnorePointer(
+                      ignoring: _paneAnim.value > 0.5,
+                      child: child,
+                    ),
+                  );
+                },
+                child: _LibraryToggleButton(
+                  onPressed: _showPane,
+                  visible: _pointerActive,
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
+    );
+  }
+}
+
+/// The sliding tray that holds the left pane content, retracting fully to
+/// the left.
+class _LeftPaneTray extends StatelessWidget {
+  const _LeftPaneTray({
+    required this.animation,
+    required this.onInteraction,
+    required this.child,
+  });
+
+  final AnimationController animation;
+  final VoidCallback onInteraction;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, _) {
+        return ClipRect(
+          child: Align(
+            alignment: Alignment.centerRight,
+            widthFactor: animation.value,
+            child: Listener(
+              behavior: HitTestBehavior.translucent,
+              onPointerDown: (_) => onInteraction(),
+              child: child,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Transparent button that lights up on mouse hover or touch.
+/// Fades to invisible after pointer inactivity.
+class _LibraryToggleButton extends StatefulWidget {
+  const _LibraryToggleButton({
+    required this.onPressed,
+    required this.visible,
+  });
+
+  final VoidCallback onPressed;
+  final bool visible;
+
+  @override
+  State<_LibraryToggleButton> createState() => _LibraryToggleButtonState();
+}
+
+class _LibraryToggleButtonState extends State<_LibraryToggleButton> {
+  bool _hovering = false;
+  bool _pressing = false;
+
+  double get _bgOpacity {
+    if (_pressing) return 0.5;
+    if (_hovering) return 0.3;
+    return 0.0;
+  }
+
+  double get _iconOpacity {
+    if (!widget.visible) return 0.0;
+    if (_hovering || _pressing) return 0.9;
+    return 0.4;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hovering = true),
+      onExit: (_) => setState(() => _hovering = false),
+      child: GestureDetector(
+        onTapDown: (_) => setState(() => _pressing = true),
+        onTapUp: (_) {
+          setState(() => _pressing = false);
+          widget.onPressed();
+        },
+        onTapCancel: () => setState(() => _pressing = false),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 300),
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: cs.onSurface.withValues(alpha: _bgOpacity),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: AnimatedOpacity(
+            opacity: _iconOpacity,
+            duration: const Duration(milliseconds: 500),
+            child: const Icon(
+              Icons.video_library,
+              color: Colors.white,
+              size: 24,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Library content that lives inside the left pane tray.
+class _LeftPaneContent extends StatelessWidget {
+  const _LeftPaneContent({
+    required this.onPlay,
+    required this.onInteraction,
+  });
+
+  final void Function(MediaItem item) onPlay;
+  final VoidCallback onInteraction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Theme.of(context).colorScheme.surface,
+      width: 420,
+      child: LibraryScreen(onPlay: onPlay),
     );
   }
 }

--- a/packages/video_player/video_player_linux/example/player/lib/mini_controller.dart
+++ b/packages/video_player/video_player_linux/example/player/lib/mini_controller.dart
@@ -293,7 +293,7 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
 
     void errorListener(Object obj) {
       final PlatformException e = obj as PlatformException;
-      value = VideoPlayerValue.erroneous(e.message!);
+      value = VideoPlayerValue.erroneous(e.message ?? e.code);
       _timer?.cancel();
       if (!initializingCompleter.isCompleted) {
         initializingCompleter.completeError(obj);
@@ -474,8 +474,10 @@ class _VideoPlayerState extends State<VideoPlayer> {
     return (_textureId == MiniController.kUninitializedTextureId ||
             !widget.controller.value.isInitialized)
         ? Container()
-        : _platform
-            .buildViewWithOptions(VideoViewOptions(playerId: _textureId));
+        : RepaintBoundary(
+            child: _platform
+                .buildViewWithOptions(VideoViewOptions(playerId: _textureId)),
+          );
   }
 }
 

--- a/packages/video_player/video_player_linux/example/player/lib/player_screen.dart
+++ b/packages/video_player/video_player_linux/example/player/lib/player_screen.dart
@@ -1,9 +1,21 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 
 import 'library.dart';
 import 'mini_controller.dart';
+
+enum FpsWindow {
+  oneSecond(Duration(seconds: 1), '1 s'),
+  fiveSeconds(Duration(seconds: 5), '5 s'),
+  tenSeconds(Duration(seconds: 10), '10 s');
+
+  const FpsWindow(this.duration, this.label);
+  final Duration duration;
+  final String label;
+}
 
 class PlayerScreen extends StatefulWidget {
   const PlayerScreen({super.key, this.item});
@@ -14,12 +26,158 @@ class PlayerScreen extends StatefulWidget {
   State<PlayerScreen> createState() => _PlayerScreenState();
 }
 
-class _PlayerScreenState extends State<PlayerScreen> {
+class _PlayerScreenState extends State<PlayerScreen>
+    with TickerProviderStateMixin {
   MiniController? _controller;
   String? _loadedUrl;
   bool _isLooping = true;
+  bool _showTrackInfo = false;
+  bool _showTimecode = false;
   double _volume = 1.0;
   double _volumeBeforeMute = 1.0;
+
+  late final AnimationController _trayAnim;
+  Timer? _trayTimer;
+  static const _trayTimeout = Duration(seconds: 5);
+
+  // FPS measurement
+  FpsWindow? _fpsWindow;
+  Ticker? _fpsTicker;
+  final List<int> _frameTimestamps = []; // elapsed microseconds
+  double _currentFps = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _trayAnim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+      value: 1.0, // start revealed
+    );
+  }
+
+  void _cycleFpsWindow() {
+    setState(() {
+      if (_fpsWindow == null) {
+        _fpsWindow = FpsWindow.oneSecond;
+      } else {
+        final next = _fpsWindow!.index + 1;
+        _fpsWindow =
+            next < FpsWindow.values.length ? FpsWindow.values[next] : null;
+      }
+    });
+
+    if (_fpsWindow != null) {
+      _startFpsTicker();
+    } else {
+      _stopFpsTicker();
+    }
+  }
+
+  void _startFpsTicker() {
+    if (_fpsTicker != null) return;
+    _frameTimestamps.clear();
+    _currentFps = 0;
+    _fpsTicker = createTicker(_onFpsTick)..start();
+  }
+
+  void _stopFpsTicker() {
+    _fpsTicker?.stop();
+    _fpsTicker?.dispose();
+    _fpsTicker = null;
+    _frameTimestamps.clear();
+    _currentFps = 0;
+  }
+
+  void _onFpsTick(Duration elapsed) {
+    final now = elapsed.inMicroseconds;
+    _frameTimestamps.add(now);
+
+    final window = _fpsWindow;
+    if (window == null) return;
+
+    final cutoff = now - window.duration.inMicroseconds;
+    // Remove timestamps older than the window
+    while (_frameTimestamps.isNotEmpty && _frameTimestamps.first < cutoff) {
+      _frameTimestamps.removeAt(0);
+    }
+    _currentFps =
+        _frameTimestamps.length / window.duration.inSeconds.toDouble();
+  }
+
+  // Keyboard controls
+  static const _volumeStep = 0.05;
+  static const _seekStep = Duration(seconds: 10);
+
+  KeyEventResult _handleKey(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    final ctrl = _controller;
+    if (ctrl == null || !ctrl.value.isInitialized) {
+      return KeyEventResult.ignored;
+    }
+    final key = event.logicalKey;
+    if (key == LogicalKeyboardKey.space) {
+      ctrl.value.isPlaying ? ctrl.pause() : ctrl.play();
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowLeft) {
+      ctrl.seekTo(ctrl.value.position - _seekStep);
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowRight) {
+      ctrl.seekTo(ctrl.value.position + _seekStep);
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowUp) {
+      setState(() => _volume = (_volume + _volumeStep).clamp(0.0, 1.0));
+      ctrl.setVolume(_volume);
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowDown) {
+      setState(() => _volume = (_volume - _volumeStep).clamp(0.0, 1.0));
+      ctrl.setVolume(_volume);
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.keyI) {
+      setState(() => _showTrackInfo = !_showTrackInfo);
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.keyT) {
+      setState(() => _showTimecode = !_showTimecode);
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.keyF) {
+      _cycleFpsWindow();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  void _showTray() {
+    _trayAnim.forward();
+    _restartTrayTimer();
+  }
+
+  void _hideTray() {
+    _trayTimer?.cancel();
+    _trayAnim.reverse();
+  }
+
+  void _restartTrayTimer() {
+    _trayTimer?.cancel();
+    _trayTimer = Timer(_trayTimeout, _hideTray);
+  }
+
+  /// Call from any control interaction to keep the tray visible.
+  void _pokeTray() {
+    if (_trayAnim.value < 1.0) {
+      _showTray();
+    } else {
+      _restartTrayTimer();
+    }
+  }
 
   @override
   void didUpdateWidget(PlayerScreen old) {
@@ -46,10 +204,6 @@ class _PlayerScreenState extends State<PlayerScreen> {
       ctrl = MiniController.network(item.url);
     }
 
-    ctrl.addListener(() {
-      if (mounted) setState(() {});
-    });
-
     setState(() => _controller = ctrl);
 
     try {
@@ -62,10 +216,14 @@ class _PlayerScreenState extends State<PlayerScreen> {
     if (!mounted) return;
     setState(() {});
     ctrl.play();
+    _showTray();
   }
 
   @override
   void dispose() {
+    _stopFpsTicker();
+    _trayTimer?.cancel();
+    _trayAnim.dispose();
     _controller?.dispose();
     super.dispose();
   }
@@ -100,210 +258,403 @@ class _PlayerScreenState extends State<PlayerScreen> {
     }
 
     final ctrl = _controller!;
-    final val = ctrl.value;
     final cs = Theme.of(context).colorScheme;
 
-    return Column(
-      children: [
-        // Video area
-        Expanded(
-          child: Container(
-            color: Colors.black,
-            child: Center(
-              child: val.isInitialized
-                  ? AspectRatio(
-                      aspectRatio: val.aspectRatio,
-                      child: Stack(
-                        alignment: Alignment.center,
-                        children: [
-                          VideoPlayer(ctrl),
-                          // Play/pause overlay
-                          _PlayPauseOverlay(controller: ctrl),
-                          // Buffering indicator
-                          if (val.isBuffering)
-                            const CircularProgressIndicator(
-                              color: Colors.white70,
-                            ),
-                        ],
-                      ),
-                    )
-                  : val.hasError
-                      ? _ErrorDisplay(message: val.errorDescription!)
-                      : const CircularProgressIndicator(),
-            ),
-          ),
-        ),
-
-        // Controls panel
-        Container(
-          decoration: BoxDecoration(
-            color: cs.surfaceContainer,
-            border: Border(
-              top: BorderSide(color: cs.outlineVariant, width: 0.5),
-            ),
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
+    // ValueListenableBuilder rebuilds only the video-value-dependent
+    // subtree on each 500ms position poll, avoiding a full
+    // _PlayerScreenState rebuild.
+    return Focus(
+      autofocus: true,
+      onKeyEvent: _handleKey,
+      child: ValueListenableBuilder<VideoPlayerValue>(
+        valueListenable: ctrl,
+        builder: (context, val, _) {
+          return Stack(
             children: [
-              // Progress bar
-              _ProgressBar(controller: ctrl),
-
-              Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                child: Row(
-                  children: [
-                    // Time display
-                    Text(
-                      '${_formatDuration(val.position)} / ${_formatDuration(val.duration)}',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        fontFeatures: [const FontFeature.tabularFigures()],
-                      ),
-                    ),
-
-                    const SizedBox(width: 24),
-
-                    // Playback controls
-                    IconButton(
-                      icon: const Icon(Icons.replay_10),
-                      tooltip: 'Rewind 10s',
-                      onPressed: val.isInitialized
-                          ? () => ctrl.seekTo(
-                              val.position - const Duration(seconds: 10))
-                          : null,
-                    ),
-                    IconButton.filled(
-                      icon: Icon(
-                        val.isPlaying ? Icons.pause : Icons.play_arrow,
-                        size: 32,
-                      ),
-                      tooltip: val.isPlaying ? 'Pause' : 'Play',
-                      onPressed: val.isInitialized
-                          ? () => val.isPlaying ? ctrl.pause() : ctrl.play()
-                          : null,
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.forward_10),
-                      tooltip: 'Forward 10s',
-                      onPressed: val.isInitialized
-                          ? () => ctrl.seekTo(
-                              val.position + const Duration(seconds: 10))
-                          : null,
-                    ),
-
-                    const SizedBox(width: 16),
-
-                    // Loop toggle
-                    IconButton(
-                      icon: Icon(
-                        Icons.loop,
-                        color: _isLooping ? cs.primary : null,
-                      ),
-                      tooltip: _isLooping ? 'Looping on' : 'Looping off',
-                      onPressed: val.isInitialized
-                          ? () {
-                              setState(() => _isLooping = !_isLooping);
-                              ctrl.setLooping(_isLooping);
-                            }
-                          : null,
-                    ),
-
-                    const Spacer(),
-
-                    // Mute button
-                    IconButton(
-                      icon: Icon(
-                        _volume == 0
-                            ? Icons.volume_off
-                            : _volume < 0.5
-                                ? Icons.volume_down
-                                : Icons.volume_up,
-                      ),
-                      tooltip: _volume == 0 ? 'Unmute' : 'Mute',
-                      onPressed: val.isInitialized
-                          ? () {
-                              if (_volume > 0) {
-                                _volumeBeforeMute = _volume;
-                                setState(() => _volume = 0);
-                              } else {
-                                setState(() => _volume = _volumeBeforeMute);
-                              }
-                              ctrl.setVolume(_volume);
-                            }
-                          : null,
-                    ),
-                    // Volume slider
-                    SizedBox(
-                      width: 120,
-                      child: Slider(
-                        value: _volume,
-                        onChanged: val.isInitialized
-                            ? (v) {
-                                setState(() => _volume = v);
-                                ctrl.setVolume(v);
-                              }
-                            : null,
-                      ),
-                    ),
-
-                    const SizedBox(width: 16),
-
-                    // Playback speed
-                    _SpeedSelector(
-                      speed: val.playbackSpeed,
-                      onChanged: val.isInitialized
-                          ? (s) => ctrl.setPlaybackSpeed(s)
-                          : null,
-                    ),
-                  ],
+              // Video area — fills entire space
+              Positioned.fill(
+                child: Container(
+                  color: Colors.black,
+                  child: Center(
+                    child: val.isInitialized
+                        ? AspectRatio(
+                            aspectRatio: val.aspectRatio,
+                            child: Stack(
+                              alignment: Alignment.center,
+                              children: [
+                                VideoPlayer(ctrl),
+                                // Play/pause overlay
+                                _PlayPauseOverlay(controller: ctrl),
+                                // Buffering indicator
+                                if (val.isBuffering)
+                                  const CircularProgressIndicator(
+                                    color: Colors.white70,
+                                  ),
+                                // Track info overlay
+                                if (_showTrackInfo)
+                                  _TrackInfoOverlay(
+                                    item: widget.item!,
+                                    value: val,
+                                    looping: _isLooping,
+                                  ),
+                                // SMPTE timecode overlay
+                                if (_showTimecode)
+                                  _TimecodeOverlay(position: val.position),
+                                // FPS overlay
+                                if (_fpsWindow != null)
+                                  _FpsOverlay(
+                                    fps: _currentFps,
+                                    window: _fpsWindow!,
+                                  ),
+                              ],
+                            ),
+                          )
+                        : val.hasError
+                            ? _ErrorDisplay(message: val.errorDescription!)
+                            : const CircularProgressIndicator(),
+                  ),
                 ),
               ),
 
-              // Now playing info
-              Container(
-                width: double.infinity,
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                decoration: BoxDecoration(
-                  color: cs.surfaceContainerLow,
-                  border: Border(
-                    top: BorderSide(color: cs.outlineVariant, width: 0.5),
+              // Transport tray — slides up from bottom
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                child: _TransportTray(
+                  animation: _trayAnim,
+                  onGripTap: _showTray,
+                  onInteraction: _pokeTray,
+                  grip: _TrayGrip(cs: cs),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: cs.surfaceContainer,
+                      border: Border(
+                        top: BorderSide(color: cs.outlineVariant, width: 0.5),
+                      ),
+                    ),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        // Progress bar
+                        _ProgressBar(controller: ctrl),
+
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 16, vertical: 8),
+                          child: Row(
+                            children: [
+                              // Time display
+                              Text(
+                                '${_formatDuration(val.position)} / ${_formatDuration(val.duration)}',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodySmall
+                                    ?.copyWith(
+                                  fontFeatures: [
+                                    const FontFeature.tabularFigures()
+                                  ],
+                                ),
+                              ),
+
+                              const SizedBox(width: 24),
+
+                              // Playback controls
+                              IconButton(
+                                icon: const Icon(Icons.replay_10),
+                                tooltip: 'Rewind 10s',
+                                onPressed: val.isInitialized
+                                    ? () => ctrl.seekTo(val.position -
+                                        const Duration(seconds: 10))
+                                    : null,
+                              ),
+                              IconButton.filled(
+                                icon: Icon(
+                                  val.isPlaying
+                                      ? Icons.pause
+                                      : Icons.play_arrow,
+                                  size: 32,
+                                ),
+                                tooltip: val.isPlaying ? 'Pause' : 'Play',
+                                onPressed: val.isInitialized
+                                    ? () => val.isPlaying
+                                        ? ctrl.pause()
+                                        : ctrl.play()
+                                    : null,
+                              ),
+                              IconButton(
+                                icon: const Icon(Icons.forward_10),
+                                tooltip: 'Forward 10s',
+                                onPressed: val.isInitialized
+                                    ? () => ctrl.seekTo(val.position +
+                                        const Duration(seconds: 10))
+                                    : null,
+                              ),
+
+                              const SizedBox(width: 16),
+
+                              // Loop toggle
+                              IconButton(
+                                icon: Icon(
+                                  Icons.loop,
+                                  color: _isLooping ? cs.primary : null,
+                                ),
+                                tooltip:
+                                    _isLooping ? 'Looping on' : 'Looping off',
+                                onPressed: val.isInitialized
+                                    ? () {
+                                        setState(
+                                            () => _isLooping = !_isLooping);
+                                        ctrl.setLooping(_isLooping);
+                                      }
+                                    : null,
+                              ),
+
+                              // Track info overlay toggle
+                              IconButton(
+                                icon: Icon(
+                                  Icons.info_outline,
+                                  color: _showTrackInfo ? cs.primary : null,
+                                ),
+                                tooltip: _showTrackInfo
+                                    ? 'Hide track info'
+                                    : 'Show track info',
+                                onPressed: val.isInitialized
+                                    ? () => setState(
+                                        () => _showTrackInfo = !_showTrackInfo)
+                                    : null,
+                              ),
+
+                              // SMPTE timecode toggle
+                              IconButton(
+                                icon: Icon(
+                                  Icons.timer_outlined,
+                                  color: _showTimecode ? cs.primary : null,
+                                ),
+                                tooltip: _showTimecode
+                                    ? 'Hide timecode'
+                                    : 'Show timecode',
+                                onPressed: val.isInitialized
+                                    ? () => setState(
+                                        () => _showTimecode = !_showTimecode)
+                                    : null,
+                              ),
+
+                              // FPS counter cycle
+                              _FpsButton(
+                                window: _fpsWindow,
+                                cs: cs,
+                                onPressed:
+                                    val.isInitialized ? _cycleFpsWindow : null,
+                              ),
+
+                              const Spacer(),
+
+                              // Mute button
+                              IconButton(
+                                icon: Icon(
+                                  _volume == 0
+                                      ? Icons.volume_off
+                                      : _volume < 0.5
+                                          ? Icons.volume_down
+                                          : Icons.volume_up,
+                                ),
+                                tooltip: _volume == 0 ? 'Unmute' : 'Mute',
+                                onPressed: val.isInitialized
+                                    ? () {
+                                        if (_volume > 0) {
+                                          _volumeBeforeMute = _volume;
+                                          setState(() => _volume = 0);
+                                        } else {
+                                          setState(() =>
+                                              _volume = _volumeBeforeMute);
+                                        }
+                                        ctrl.setVolume(_volume);
+                                      }
+                                    : null,
+                              ),
+                              // Volume slider
+                              SizedBox(
+                                width: 120,
+                                child: Slider(
+                                  value: _volume,
+                                  onChanged: val.isInitialized
+                                      ? (v) {
+                                          setState(() => _volume = v);
+                                          ctrl.setVolume(v);
+                                        }
+                                      : null,
+                                ),
+                              ),
+
+                              const SizedBox(width: 16),
+
+                              // Playback speed
+                              _SpeedSelector(
+                                speed: val.playbackSpeed,
+                                onChanged: val.isInitialized
+                                    ? (s) => ctrl.setPlaybackSpeed(s)
+                                    : null,
+                              ),
+                            ],
+                          ),
+                        ),
+
+                        // Now playing info
+                        Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 16, vertical: 8),
+                          decoration: BoxDecoration(
+                            color: cs.surfaceContainerLow,
+                            border: Border(
+                              top: BorderSide(
+                                  color: cs.outlineVariant, width: 0.5),
+                            ),
+                          ),
+                          child: Row(
+                            children: [
+                              Icon(
+                                widget.item!.source == MediaSource.asset
+                                    ? Icons.folder
+                                    : Icons.cloud,
+                                size: 16,
+                                color: cs.onSurfaceVariant,
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Text(
+                                  '${widget.item!.name}  -  ${widget.item!.url}',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .bodySmall
+                                      ?.copyWith(color: cs.onSurfaceVariant),
+                                ),
+                              ),
+                              if (val.isInitialized)
+                                Text(
+                                  '${val.size.width.toInt()}x${val.size.height.toInt()}',
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .bodySmall
+                                      ?.copyWith(color: cs.onSurfaceVariant),
+                                ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-                child: Row(
-                  children: [
-                    Icon(
-                      widget.item!.source == MediaSource.asset
-                          ? Icons.folder
-                          : Icons.cloud,
-                      size: 16,
-                      color: cs.onSurfaceVariant,
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        '${widget.item!.name}  -  ${widget.item!.url}',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: cs.onSurfaceVariant,
-                            ),
-                      ),
-                    ),
-                    if (val.isInitialized)
-                      Text(
-                        '${val.size.width.toInt()}x${val.size.height.toInt()}',
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: cs.onSurfaceVariant,
-                            ),
-                      ),
-                  ],
                 ),
               ),
             ],
-          ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Grip handle shown at the top of the transport tray.
+class _TrayGrip extends StatelessWidget {
+  const _TrayGrip({required this.cs});
+
+  final ColorScheme cs;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        width: 40,
+        height: 4,
+        decoration: BoxDecoration(
+          color: cs.onSurfaceVariant.withValues(alpha: 0.5),
+          borderRadius: BorderRadius.circular(2),
         ),
-      ],
+      ),
+    );
+  }
+}
+
+/// Wraps the transport controls with a slide animation and a draggable grip.
+///
+/// The [grip] is always visible at the bottom of the screen. The [child]
+/// (the actual controls) slides up/down driven by [animation].
+class _TransportTray extends StatelessWidget {
+  const _TransportTray({
+    required this.animation,
+    required this.onGripTap,
+    required this.onInteraction,
+    required this.grip,
+    required this.child,
+  });
+
+  final AnimationController animation;
+  final VoidCallback onGripTap;
+  final VoidCallback onInteraction;
+  final Widget grip;
+  final Widget child;
+
+  static const double _gripHeight = 24.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, _) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Grip — always visible, tappable and draggable
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: onGripTap,
+              onVerticalDragUpdate: (details) {
+                // Dragging up → reveal, dragging down → hide
+                if (details.primaryDelta != null) {
+                  if (details.primaryDelta! < -2) {
+                    onGripTap();
+                  }
+                }
+              },
+              onVerticalDragEnd: (details) {
+                final velocity = details.primaryVelocity ?? 0;
+                if (velocity > 300) {
+                  // Fling downward → hide
+                  animation.reverse();
+                } else if (velocity < -300) {
+                  // Fling upward → show
+                  onGripTap();
+                }
+              },
+              child: Container(
+                height: _gripHeight,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surfaceContainer,
+                  borderRadius: const BorderRadius.vertical(
+                    top: Radius.circular(12),
+                  ),
+                ),
+                child: Center(child: grip),
+              ),
+            ),
+            // Controls panel — clips and slides
+            ClipRect(
+              child: Align(
+                alignment: Alignment.topCenter,
+                heightFactor: animation.value,
+                child: Listener(
+                  behavior: HitTestBehavior.translucent,
+                  onPointerDown: (_) => onInteraction(),
+                  child: child,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }
@@ -473,6 +824,202 @@ class _SpeedSelector extends StatelessWidget {
       child: Chip(
         avatar: const Icon(Icons.speed, size: 18),
         label: Text('${speed}x'),
+      ),
+    );
+  }
+}
+
+class _TrackInfoOverlay extends StatelessWidget {
+  const _TrackInfoOverlay({
+    required this.item,
+    required this.value,
+    required this.looping,
+  });
+
+  final MediaItem item;
+  final VideoPlayerValue value;
+  final bool looping;
+
+  String _formatDuration(Duration d) {
+    final h = d.inHours;
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return h > 0 ? '$h:$m:$s' : '$m:$s';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final w = value.size.width.toInt();
+    final h = value.size.height.toInt();
+
+    return Positioned(
+      left: 12,
+      top: 12,
+      child: IgnorePointer(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          decoration: BoxDecoration(
+            color: Colors.black54,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: DefaultTextStyle(
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 13,
+              height: 1.5,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(item.name,
+                    style: const TextStyle(
+                        fontWeight: FontWeight.bold, fontSize: 14)),
+                Text(item.url,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style:
+                        const TextStyle(fontSize: 11, color: Colors.white70)),
+                const SizedBox(height: 4),
+                Text('Resolution: ${w}x$h'),
+                Text('Duration: ${_formatDuration(value.duration)}'),
+                Text('Position: ${_formatDuration(value.position)}'),
+                Text('Speed: ${value.playbackSpeed}x'),
+                Text('Looping: ${looping ? "on" : "off"}'),
+                Text(
+                    'Source: ${item.source == MediaSource.asset ? "local asset" : "network"}'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TimecodeOverlay extends StatelessWidget {
+  const _TimecodeOverlay({required this.position});
+
+  final Duration position;
+
+  /// Format duration as SMPTE timecode HH:MM:SS:FF (assuming 30 fps).
+  String _toSmpte(Duration d) {
+    final total = d.inMilliseconds;
+    final h = (total ~/ 3600000).toString().padLeft(2, '0');
+    final m = ((total ~/ 60000) % 60).toString().padLeft(2, '0');
+    final s = ((total ~/ 1000) % 60).toString().padLeft(2, '0');
+    final f = ((total % 1000) * 30 ~/ 1000).toString().padLeft(2, '0');
+    return '$h:$m:$s:$f';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      right: 12,
+      bottom: 12,
+      child: IgnorePointer(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          decoration: BoxDecoration(
+            color: Colors.black54,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(
+            _toSmpte(position),
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 16,
+              fontFamily: 'monospace',
+              fontFeatures: [FontFeature.tabularFigures()],
+              letterSpacing: 1.5,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FpsButton extends StatelessWidget {
+  const _FpsButton({
+    required this.window,
+    required this.cs,
+    required this.onPressed,
+  });
+
+  final FpsWindow? window;
+  final ColorScheme cs;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final active = window != null;
+    return Tooltip(
+      message:
+          active ? 'FPS avg ${window!.label} (click to cycle)' : 'Show FPS',
+      child: InkWell(
+        borderRadius: BorderRadius.circular(8),
+        onTap: onPressed,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.speed_outlined,
+                size: 20,
+                color: active ? cs.primary : null,
+              ),
+              if (active) ...[
+                const SizedBox(width: 4),
+                Text(
+                  window!.label,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: cs.primary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FpsOverlay extends StatelessWidget {
+  const _FpsOverlay({
+    required this.fps,
+    required this.window,
+  });
+
+  final double fps;
+  final FpsWindow window;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      right: 12,
+      top: 12,
+      child: IgnorePointer(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          decoration: BoxDecoration(
+            color: Colors.black54,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(
+            '${fps.toStringAsFixed(1)} FPS (${window.label})',
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 14,
+              fontFamily: 'monospace',
+              fontFeatures: [FontFeature.tabularFigures()],
+            ),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
- Add track info overlay (name, resolution, duration, codec, source) with 'i' key / button toggle
- Add SMPTE timecode overlay (HH:MM:SS:FF @ 30fps) with 't' key toggle
- Add FPS counter overlay averaging over 1s/5s/10s windows, cycled with 'f' key
- Convert transport controls to a sliding tray that auto-hides after timeout, with grip handle to reveal
- Convert library pane to a left-sliding tray that retracts fully; add hover-activated library toggle button and left-edge swipe gesture
- Add keyboard shortcuts: space (play/pause), arrows (seek/volume)
- Wrap Texture widget in RepaintBoundary to isolate repaints
- Replace blanket setState listener with ValueListenableBuilder for targeted rebuilds on position/buffering updates
- Fix null check crash in error listener (e.message ?? e.code)

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
